### PR TITLE
clf_infer: base model default tokenizer

### DIFF
--- a/src/linktransformer/utils.py
+++ b/src/linktransformer/utils.py
@@ -349,7 +349,7 @@ def predict_rows_with_openai(
 def _load_base_model_name(model_path: str):
     """
     This function loads the base model name from the model name string.
-    :param model_name: (str) model name string
+    :param model_path: (str) filepath to the model to use
     :returns: (str) base model name
     """
 


### PR DESCRIPTION
This change streamlines topic classification inference with models trained in native huggingface pipeline. The huggingface Trainer does not save the tokenizer_config.json and other tokenizer files by default, which will result in an OSError when loading such model for inference in LinkTransformer. 

Added:
- src/linktransformer/utils.py: add an alternative to load the base model default tokenizer as in config.json. 

Not tested yet. Do not merge. 
